### PR TITLE
Remove hard dependency on plone.app.referenceablebehavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ There's a frood who really knows where his towel is.
 1.0a2 (unreleased)
 ------------------
 
+- Remove hard dependency on plone.app.referenceablebehavior as Archetypes is no longer the default framework in Plone 5.
+  Under Plone < 5.0 you should now explicitly add it to the `eggs` part of your buildout configuration to avoid issues while upgrading.
+  [hvelarde]
+
 - Avoid photo distorting when landscape format is used.
   [rodfersou]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'collective.js.cycle2',
         'plone.api',
         'plone.app.dexterity [grok, relations]',
-        'plone.app.referenceablebehavior',
         'plone.app.relationfield',
         'plone.app.textfield',
         'plone.app.upgrade',

--- a/src/sc/photogallery/configure.zcml
+++ b/src/sc/photogallery/configure.zcml
@@ -9,7 +9,6 @@
   <i18n:registerTranslations directory="locales" />
 
   <include package="plone.app.dexterity" />
-  <include package="plone.app.referenceablebehavior" />
   <include package="plone.app.relationfield" />
 
   <permission id="sc.photogallery.Setup" title="sc.photogallery: Setup" />

--- a/src/sc/photogallery/profiles/default/types/Photo_Gallery.xml
+++ b/src/sc/photogallery/profiles/default/types/Photo_Gallery.xml
@@ -26,7 +26,6 @@
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation" />
     <element value="plone.app.dexterity.behaviors.metadata.IDublinCore" />
-    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
     <element value="plone.app.relationfield.behavior.IRelatedItems" />
   </property>
 

--- a/src/sc/photogallery/testing.py
+++ b/src/sc/photogallery/testing.py
@@ -30,16 +30,6 @@ IMAGES = [
 ]
 
 
-def turn_off_referenceablebehavior():
-    """FIXME"""
-    from plone.dexterity.interfaces import IDexterityFTI
-    from zope.component import queryUtility
-    fti = queryUtility(IDexterityFTI, name='Photo Gallery')
-    behaviors = list(fti.behaviors)
-    behaviors.remove('plone.app.referenceablebehavior.referenceable.IReferenceable')
-    fti.behaviors = tuple(behaviors)
-
-
 class Fixture(PloneSandboxLayer):
 
     defaultBases = (PLONE_FIXTURE,)
@@ -74,9 +64,6 @@ class Fixture(PloneSandboxLayer):
         self.applyProfile(portal, 'collective.js.cycle2:default')
 
         self.applyProfile(portal, 'sc.photogallery:default')
-
-        if PLONE_VERSION >= '5.0':
-            turn_off_referenceablebehavior()
 
         current_dir = os.path.abspath(os.path.dirname(__file__))
         for img in IMAGES:

--- a/src/sc/photogallery/tests/test_photogallery.py
+++ b/src/sc/photogallery/tests/test_photogallery.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 from plone import api
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
-from plone.app.referenceablebehavior.referenceable import IReferenceable
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.namedfile.tests.test_image import zptlogo
-from plone.uuid.interfaces import IAttributeUUID
 from sc.photogallery.interfaces import IPhotoGallery
 from sc.photogallery.testing import INTEGRATION_TESTING
-from sc.photogallery.testing import PLONE_VERSION
 from zope.component import createObject
 from zope.component import queryUtility
 
@@ -46,11 +43,6 @@ class PhotoGalleryTestCase(unittest.TestCase):
 
     def test_exclude_from_navigation_behavior(self):
         self.assertTrue(IExcludeFromNavigation.providedBy(self.gallery))
-
-    @unittest.skipIf(PLONE_VERSION >= '5.0', 'FIXME')
-    def test_is_referenceable(self):
-        self.assertTrue(IReferenceable.providedBy(self.gallery))
-        self.assertTrue(IAttributeUUID.providedBy(self.gallery))
 
     def test_allowed_content_types(self):
         allowed_types = [t.getId() for t in self.gallery.allowedContentTypes()]


### PR DESCRIPTION
Archetypes is no longer the default framework in Plone 5.